### PR TITLE
Log more details in the configmap pipeline

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -97,6 +97,11 @@ default:
       name: area/performance
       target: both
       addedBy: label
+    - color: 8822ee
+      description: Issues or PRs that are related to demos.
+      name: area/demo
+      target: both
+      addedBy: label
 
     # Kinds
     - color: d876e3

--- a/tekton/resources/cd/configmap-template.yaml
+++ b/tekton/resources/cd/configmap-template.yaml
@@ -57,12 +57,15 @@ spec:
           - name: KUBECONFIG
             value: /workspace/$(resources.inputs.targetCluster.name)/kubeconfig
         steps:
+        - name: hello-digital-developer-conference
+          image: busybox
+          script:
+            echo 'Hello everyone!'
         - name: fetch-current-config
           image: gcr.io/tekton-releases/dogfooding/kubectl
           script: |
             #!/bin/sh
-            set -e
-            set +x
+            set -ex
             kubectl get configmap -n $(params.namespace) \
               $(params.configMapName) -o template \
               --template='{{ index .data "$(params.configMapKey)" }}' > \
@@ -84,15 +87,16 @@ spec:
             echo "diff [current-config] [new config]"
             has_diff=0
             diff /workspace/$(params.configMapKey) \
-              $(resources.inputs.source.path)/$(params.configPath) 2> /dev/null || has_diff=1
+              $(resources.inputs.source.path)/$(params.configPath) || has_diff=1
             if [ $has_diff -eq 0 ]; then
+              echo "No change in config detected. Nothing to be done."
               exit 0
             fi
             # Apply configuration changes
             kubectl create configmap $(params.configMapName) \
               --from-file=$(params.configMapKey)=$(resources.inputs.source.path)/$(params.configPath) \
               --dry-run -o yaml | \
-              kubectl replace configmap $(params.configMapName) -n $(params.namespace) -f - 2> /dev/null
+              kubectl replace configmap $(params.configMapName) -n $(params.namespace) -f -
       params:
       - name: configPath
         value: $(tt.params.configPath)


### PR DESCRIPTION
Make the configmap deployment pipeline more verbose to help
track when a deployment actually happened.


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._